### PR TITLE
feat: real-world query builder gaps (#13)

### DIFF
--- a/src/query/__tests__/expressions.test.ts
+++ b/src/query/__tests__/expressions.test.ts
@@ -343,4 +343,97 @@ describe('fn — function helpers', () => {
       expect(expr.params).toHaveLength(1);
     });
   });
+
+  describe('argMaxIf / argMinIf', () => {
+    it('argMaxIf with single version column', () => {
+      const condition = fn.raw('captured_at BETWEEN now() - INTERVAL 10 MINUTE AND now()');
+      const expr = fn.argMaxIf('volume', 'captured_at', condition);
+      expect(expr.sql).toBe(
+        'argMaxIf(volume, captured_at, captured_at BETWEEN now() - INTERVAL 10 MINUTE AND now())',
+      );
+    });
+
+    it('argMinIf with single version column', () => {
+      const condition = fn.raw('active = 1');
+      const expr = fn.argMinIf('price', 'updated_at', condition);
+      expect(expr.sql).toBe('argMinIf(price, updated_at, active = 1)');
+    });
+
+    it('argMaxIf with tuple version columns', () => {
+      const condition = fn.raw('status = 1');
+      const expr = fn.argMaxIf('name', ['vid', 'updated_at'], condition);
+      expect(expr.sql).toBe('argMaxIf(name, (vid, updated_at), status = 1)');
+    });
+
+    it('argMaxIf with alias', () => {
+      const condition = fn.raw('active = 1');
+      expect(fn.argMaxIf('volume', 'ts', condition).as('vol').toString())
+        .toBe('argMaxIf(volume, ts, active = 1) AS vol');
+    });
+
+    it('argMaxIf propagates params from condition Expression', () => {
+      const p = new Param('n', 'UInt32');
+      const condition = fn.raw('captured_at > now() - INTERVAL ', p, ' MINUTE');
+      const expr = fn.argMaxIf('volume', 'captured_at', condition);
+      expect(expr.params).toHaveLength(1);
+      expect(expr.params[0]!.name).toBe('n');
+      expect(expr.sql).toBe('argMaxIf(volume, captured_at, captured_at > now() - INTERVAL {n:UInt32} MINUTE)');
+    });
+  });
+
+  describe('interval / ago / sub / add', () => {
+    it('fn.interval()', () => {
+      expect(fn.interval(5, 'MINUTE').sql).toBe('INTERVAL 5 MINUTE');
+    });
+
+    it('fn.interval with alias', () => {
+      expect(fn.interval(1, 'HOUR').as('offset').toString()).toBe('INTERVAL 1 HOUR AS offset');
+    });
+
+    it('fn.ago()', () => {
+      expect(fn.ago(5, 'MINUTE').sql).toBe('now() - INTERVAL 5 MINUTE');
+    });
+
+    it('fn.ago with DAY', () => {
+      expect(fn.ago(7, 'DAY').sql).toBe('now() - INTERVAL 7 DAY');
+    });
+
+    it('fn.sub()', () => {
+      const expr = fn.sub(fn.now(), fn.interval(5, 'MINUTE'));
+      expect(expr.sql).toBe('(now()) - (INTERVAL 5 MINUTE)');
+    });
+
+    it('fn.add()', () => {
+      const expr = fn.add(fn.now(), fn.interval(1, 'HOUR'));
+      expect(expr.sql).toBe('(now()) + (INTERVAL 1 HOUR)');
+    });
+
+    it('fn.sub propagates params', () => {
+      const p = new Param('n', 'UInt32');
+      const left = fn.raw('col_a + ', p);
+      const right = fn.now();
+      const expr = fn.sub(left, right);
+      expect(expr.params).toHaveLength(1);
+      expect(expr.params[0]!.name).toBe('n');
+    });
+
+    it('fn.add propagates params from both sides', () => {
+      const p1 = new Param('a', 'UInt32');
+      const p2 = new Param('b', 'UInt32');
+      const expr = fn.add(fn.raw('x + ', p1), fn.raw('y + ', p2));
+      expect(expr.params).toHaveLength(2);
+    });
+
+    it('fn.sub composes with fn.now and fn.interval', () => {
+      const expr = fn.sub(fn.now(), fn.interval(10, 'SECOND'));
+      expect(expr.sql).toBe('(now()) - (INTERVAL 10 SECOND)');
+    });
+
+    it('supports all interval units', () => {
+      const units = ['SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'YEAR'] as const;
+      for (const unit of units) {
+        expect(fn.interval(1, unit).sql).toBe(`INTERVAL 1 ${unit}`);
+      }
+    });
+  });
 });

--- a/src/query/__tests__/select-builder.test.ts
+++ b/src/query/__tests__/select-builder.test.ts
@@ -334,7 +334,17 @@ describe('SelectBuilder', () => {
     });
   });
 
-  describe('NOT LIKE / ILIKE', () => {
+  describe('LIKE / NOT LIKE / ILIKE', () => {
+    it('builds WHERE LIKE with Param', () => {
+      const { sql, params } = qb
+        .selectFrom('users')
+        .select(['user_id'])
+        .where('name', 'LIKE', qb.param('pattern', 'String'))
+        .compile();
+      expect(sql).toContain('WHERE name LIKE {pattern:String}');
+      expect(params).toHaveProperty('pattern');
+    });
+
     it('builds WHERE NOT LIKE', () => {
       const { sql } = qb
         .selectFrom('users')
@@ -962,6 +972,47 @@ describe('SelectBuilder', () => {
         .compile();
       expect(sql).toContain('WHERE name != {name:String} AND score > {min:Float64}');
       expect(sql).not.toContain('max');
+    });
+  });
+
+  describe('INSERT ... SELECT', () => {
+    it('builds INSERT INTO with SELECT', () => {
+      const select = qb
+        .selectFrom('users')
+        .select(['user_id', fn.argMax('name', 'updated_at').as('name')])
+        .groupBy('user_id');
+      const { sql, params } = qb.insertFrom('users_latest', select).compile();
+      expect(sql).toBe(
+        'INSERT INTO users_latest\nSELECT user_id, argMax(name, updated_at) AS name\nFROM users\nGROUP BY user_id',
+      );
+      expect(params).toEqual({});
+    });
+
+    it('merges params from the inner SELECT', () => {
+      const select = qb
+        .selectFrom('users')
+        .select(['user_id', 'name'])
+        .where('score', '>', qb.param('min', 'Float64'));
+      const { sql, params } = qb.insertFrom('users_filtered', select).compile();
+      expect(sql).toContain('INSERT INTO users_filtered');
+      expect(sql).toContain('WHERE score > {min:Float64}');
+      expect(params).toHaveProperty('min');
+    });
+  });
+
+  describe('TRUNCATE', () => {
+    it('builds TRUNCATE TABLE', () => {
+      const { sql, params } = qb.truncate('users_staging').compile();
+      expect(sql).toBe('TRUNCATE TABLE users_staging');
+      expect(params).toEqual({});
+    });
+  });
+
+  describe('EXCHANGE TABLES', () => {
+    it('builds EXCHANGE TABLES ... AND ...', () => {
+      const { sql, params } = qb.exchangeTables('users_latest', 'users_latest_next').compile();
+      expect(sql).toBe('EXCHANGE TABLES users_latest AND users_latest_next');
+      expect(params).toEqual({});
     });
   });
 });

--- a/src/query/expressions.ts
+++ b/src/query/expressions.ts
@@ -284,6 +284,14 @@ export const fn = {
   avgIf(column: string, condition: string): Expression {
     return new Expression(`avgIf(${column}, ${condition})`);
   },
+  argMaxIf(column: string, versionColumn: string | string[], condition: Expression): Expression {
+    const ver = Array.isArray(versionColumn) ? `(${versionColumn.join(', ')})` : versionColumn;
+    return new Expression(`argMaxIf(${column}, ${ver}, ${condition.sql})`, undefined, [...condition.params]);
+  },
+  argMinIf(column: string, versionColumn: string | string[], condition: Expression): Expression {
+    const ver = Array.isArray(versionColumn) ? `(${versionColumn.join(', ')})` : versionColumn;
+    return new Expression(`argMinIf(${column}, ${ver}, ${condition.sql})`, undefined, [...condition.params]);
+  },
 
   // --- Aggregate -State combinators (for writing to AggregatingMergeTree) ---
 
@@ -337,6 +345,21 @@ export const fn = {
   },
   quantileMerge(level: number, column: string): Expression {
     return new Expression(`quantileMerge(${level})(${column})`);
+  },
+
+  // --- Arithmetic / interval helpers ---
+
+  interval(n: number, unit: 'SECOND' | 'MINUTE' | 'HOUR' | 'DAY' | 'WEEK' | 'MONTH' | 'YEAR'): Expression {
+    return new Expression(`INTERVAL ${n} ${unit}`);
+  },
+  ago(n: number, unit: 'SECOND' | 'MINUTE' | 'HOUR' | 'DAY' | 'WEEK' | 'MONTH' | 'YEAR'): Expression {
+    return new Expression(`now() - INTERVAL ${n} ${unit}`);
+  },
+  sub(left: Expression, right: Expression): Expression {
+    return new Expression(`(${left.sql}) - (${right.sql})`, undefined, [...left.params, ...right.params]);
+  },
+  add(left: Expression, right: Expression): Expression {
+    return new Expression(`(${left.sql}) + (${right.sql})`, undefined, [...left.params, ...right.params]);
   },
 
   /** Raw SQL expression — escape hatch for anything not covered.

--- a/src/query/query-builder.ts
+++ b/src/query/query-builder.ts
@@ -34,6 +34,12 @@ export interface QueryBuilder<DB extends DatabaseSchema> {
     name: N,
     builder: B,
   ): WithBuilder<DB & Record<N, CteSchema<InferResult<B>>>>;
+  /** INSERT INTO target SELECT ... — atomic insert-from-select. */
+  insertFrom(table: string, selectQuery: { compile(): CompiledQuery<unknown> }): { compile(): CompiledQuery };
+  /** TRUNCATE TABLE statement. */
+  truncate(table: string): { compile(): CompiledQuery };
+  /** EXCHANGE TABLES a AND b (atomic table swap). */
+  exchangeTables(tableA: string, tableB: string): { compile(): CompiledQuery };
   fn: typeof fn;
 }
 
@@ -90,6 +96,28 @@ export function createQueryBuilder<DB extends DatabaseSchema>(): QueryBuilder<DB
       builder: Subquery | { compile(): CompiledQuery<unknown> },
     ) {
       return createWithBuilder(name, builder, []);
+    },
+    insertFrom(table: string, selectQuery: { compile(): CompiledQuery<unknown> }) {
+      return {
+        compile(): CompiledQuery {
+          const compiled = selectQuery.compile();
+          return { sql: `INSERT INTO ${table}\n${compiled.sql}`, params: compiled.params };
+        },
+      };
+    },
+    truncate(table: string) {
+      return {
+        compile(): CompiledQuery {
+          return { sql: `TRUNCATE TABLE ${table}`, params: {} };
+        },
+      };
+    },
+    exchangeTables(tableA: string, tableB: string) {
+      return {
+        compile(): CompiledQuery {
+          return { sql: `EXCHANGE TABLES ${tableA} AND ${tableB}`, params: {} };
+        },
+      };
     },
     fn,
   };


### PR DESCRIPTION
## Summary
- **argMaxIf / argMinIf** — conditional dedup for ReplacingMergeTree with time windows
- **INTERVAL expressions** — `fn.interval()`, `fn.ago()`, `fn.sub()`, `fn.add()` for time arithmetic
- **INSERT ... SELECT** — `qb.insertFrom('target', selectQuery)` for atomic swap patterns
- **TRUNCATE / EXCHANGE TABLES** — DDL helpers for zero-downtime table swaps
- **LIKE with Param** — confirmed working, added tests

Closes #13

## Test plan
- 20 new tests (431 total), all passing
- Typecheck clean