### PR TITLE
refactor: codebase cleanup — deduplicate, fix bugs, harden security

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -74,7 +74,7 @@ export function createClient<DB extends DatabaseSchema>(
       });
       const stream = result.stream<T>();
       for await (const rows of stream) {
-        yield rows.map((row) => row.json());
+        yield rows.map((row) => row.json<T>());
       }
     },
 

--- a/src/codegen/cli.ts
+++ b/src/codegen/cli.ts
@@ -240,7 +240,7 @@ const diffCommand = defineCommand({
 const main = defineCommand({
   meta: {
     name: 'chtype',
-    version: '0.1.0',
+    version: '0.9.0',
     description: 'Type-safe ClickHouse toolkit for TypeScript',
   },
   subCommands: {

--- a/src/codegen/generator.ts
+++ b/src/codegen/generator.ts
@@ -12,7 +12,6 @@ import { type TypeMapperOptions, mapClickHouseType, isAggregateFunctionType } fr
 
 export interface GeneratorOptions extends TypeMapperOptions {
   database: string;
-  command?: string;
 }
 
 /** Valid JS identifier pattern — names that don't match need quoting. */
@@ -20,15 +19,16 @@ const VALID_IDENTIFIER = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
 
 /** Quote a property name if it's not a valid JS identifier. */
 function quoteProperty(name: string): string {
-  return VALID_IDENTIFIER.test(name) ? name : `"${name}"`;
+  return VALID_IDENTIFIER.test(name) ? name : JSON.stringify(name);
 }
 
 /** Convert snake_case to PascalCase, preserving casing within segments. */
 function snakeToPascal(s: string): string {
-  return s
+  const result = s
     .split('_')
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join('');
+  return /^\d/.test(result) ? `_${result}` : result;
 }
 
 function rowName(tableName: string): string {

--- a/src/codegen/introspect.ts
+++ b/src/codegen/introspect.ts
@@ -177,7 +177,7 @@ export function parseSourceTable(asSelect: string): string | null {
   if (!asSelect) return null;
   const match = asSelect.match(/\bFROM\s+([\s\S]+?)(?:\s+(?:WHERE|GROUP|ORDER|LIMIT|HAVING|PREWHERE|UNION|INTERSECT|EXCEPT|SETTINGS|FORMAT|INTO|;)|$)/i);
   if (!match) return null;
-  const raw = match[1]!.trim().replace(/`/g, '');
+  const raw = match[1]!.trim().replace(/[`"]/g, '');
   const parts = raw.split('.');
   return parts[parts.length - 1]!;
 }

--- a/src/migrate/generator.ts
+++ b/src/migrate/generator.ts
@@ -153,5 +153,5 @@ function quoteIdentifier(name: string): string {
 
 /** Escape and quote a string for use in SQL (single quotes). */
 function quoteSingleString(value: string): string {
-  return `'${value.replace(/'/g, "\\'")}'`;
+  return `'${value.replace(/'/g, "''")}'`;
 }

--- a/src/query/__tests__/delete-builder.test.ts
+++ b/src/query/__tests__/delete-builder.test.ts
@@ -87,4 +87,33 @@ describe('DeleteBuilder', () => {
       .compile();
     expect(sql).toBe('ALTER TABLE users DELETE WHERE score BETWEEN {low:Float64} AND {high:Float64}');
   });
+
+  describe('whereIf', () => {
+    it('adds condition when truthy', () => {
+      const { sql } = qb
+        .deleteFrom('users')
+        .where('user_id', '=', qb.param('id', 'String'))
+        .whereIf(true, 'score', '<', qb.param('min', 'Float64'))
+        .compile();
+      expect(sql).toContain('DELETE WHERE user_id = {id:String} AND score < {min:Float64}');
+    });
+
+    it('skips condition when falsy', () => {
+      const { sql } = qb
+        .deleteFrom('users')
+        .where('user_id', '=', qb.param('id', 'String'))
+        .whereIf(false, 'score', '<', qb.param('min', 'Float64'))
+        .compile();
+      expect(sql).not.toContain('score');
+    });
+
+    it('skips condition when null', () => {
+      const { sql } = qb
+        .deleteFrom('users')
+        .where('user_id', '=', qb.param('id', 'String'))
+        .whereIf(null, 'score', '<', qb.param('min', 'Float64'))
+        .compile();
+      expect(sql).not.toContain('score');
+    });
+  });
 });

--- a/src/query/__tests__/expressions.test.ts
+++ b/src/query/__tests__/expressions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { fn } from '../expressions.js';
+import { fn, or, and, Expression } from '../expressions.js';
 import { Param } from '../param.js';
 
 describe('fn — function helpers', () => {
@@ -434,6 +434,34 @@ describe('fn — function helpers', () => {
       for (const unit of units) {
         expect(fn.interval(1, unit).sql).toBe(`INTERVAL 1 ${unit}`);
       }
+    });
+  });
+
+  describe('ConditionGroup param propagation', () => {
+    it('collects params from plain Expression passed as condition', () => {
+      const p = new Param('n', 'UInt32');
+      const expr = fn.raw('col > now() - INTERVAL ', p, ' HOUR');
+      const group = or(expr);
+      expect(group.params).toHaveLength(1);
+      expect(group.params[0]!.name).toBe('n');
+    });
+
+    it('collects params from Expression value in condition tuple', () => {
+      const p = new Param('n', 'UInt32');
+      const expr = fn.raw('now() - INTERVAL ', p, ' DAY');
+      const group = or(['col', '>', expr]);
+      expect(group.params).toHaveLength(1);
+      expect(group.params[0]!.name).toBe('n');
+    });
+
+    it('collects params from multiple Expression conditions', () => {
+      const p1 = new Param('a', 'UInt32');
+      const p2 = new Param('b', 'String');
+      const expr1 = fn.raw('x > ', p1);
+      const expr2 = fn.raw('y = ', p2);
+      const group = and(expr1, expr2);
+      expect(group.params).toHaveLength(2);
+      expect(group.params.map((p) => p.name)).toEqual(['a', 'b']);
     });
   });
 });

--- a/src/query/__tests__/select-builder.test.ts
+++ b/src/query/__tests__/select-builder.test.ts
@@ -62,6 +62,49 @@ describe('SelectBuilder', () => {
     expect(sql).toContain('HAVING total > {min:UInt32}');
   });
 
+  it('builds HAVING with IS NOT NULL (unary)', () => {
+    const { sql } = qb
+      .selectFrom('users')
+      .select([qb.fn.count().as('total')])
+      .groupBy('name')
+      .having('total', 'IS NOT NULL')
+      .compile();
+    expect(sql).toContain('HAVING total IS NOT NULL');
+  });
+
+  it('builds HAVING with BETWEEN', () => {
+    const { sql } = qb
+      .selectFrom('users')
+      .select([qb.fn.count().as('total')])
+      .groupBy('name')
+      .having('total', 'BETWEEN', [qb.param('low', 'UInt32'), qb.param('high', 'UInt32')])
+      .compile();
+    expect(sql).toContain('HAVING total BETWEEN {low:UInt32} AND {high:UInt32}');
+  });
+
+  it('builds HAVING with IN (set op)', () => {
+    const { sql } = qb
+      .selectFrom('users')
+      .select([qb.fn.count().as('total')])
+      .groupBy('name')
+      .having('total', 'IN', qb.param('vals', 'Array(UInt32)'))
+      .compile();
+    expect(sql).toContain('HAVING total IN {vals:Array(UInt32)}');
+  });
+
+  it('builds HAVING with or() group', () => {
+    const { sql } = qb
+      .selectFrom('users')
+      .select([qb.fn.count().as('total')])
+      .groupBy('name')
+      .having(or(
+        ['total', '>', qb.param('min', 'UInt32')],
+        ['total', '<', qb.param('max', 'UInt32')],
+      ))
+      .compile();
+    expect(sql).toContain('HAVING (total > {min:UInt32} OR total < {max:UInt32})');
+  });
+
   it('builds ORDER BY', () => {
     const { sql } = qb.selectFrom('users').select(['user_id']).orderBy('score', 'DESC').compile();
     expect(sql).toContain('ORDER BY score DESC');
@@ -1006,6 +1049,12 @@ describe('SelectBuilder', () => {
       expect(sql).toBe('TRUNCATE TABLE users_staging');
       expect(params).toEqual({});
     });
+
+    it('rejects invalid table names', () => {
+      expect(() => {
+        qb.truncate('bad; DROP TABLE users');
+      }).toThrow('Invalid table name');
+    });
   });
 
   describe('EXCHANGE TABLES', () => {
@@ -1013,6 +1062,27 @@ describe('SelectBuilder', () => {
       const { sql, params } = qb.exchangeTables('users_latest', 'users_latest_next').compile();
       expect(sql).toBe('EXCHANGE TABLES users_latest AND users_latest_next');
       expect(params).toEqual({});
+    });
+
+    it('rejects invalid first table name', () => {
+      expect(() => {
+        qb.exchangeTables('bad; DROP TABLE', 'ok');
+      }).toThrow('Invalid table name');
+    });
+
+    it('rejects invalid second table name', () => {
+      expect(() => {
+        qb.exchangeTables('ok', 'bad; DROP TABLE');
+      }).toThrow('Invalid table name');
+    });
+  });
+
+  describe('INSERT ... SELECT validation', () => {
+    it('rejects invalid table names in insertFrom', () => {
+      const select = qb.selectFrom('users').select(['user_id']);
+      expect(() => {
+        qb.insertFrom('bad; DROP TABLE users', select);
+      }).toThrow('Invalid table name');
     });
   });
 });

--- a/src/query/__tests__/update-builder.test.ts
+++ b/src/query/__tests__/update-builder.test.ts
@@ -105,4 +105,36 @@ describe('UpdateBuilder', () => {
       'ALTER TABLE users UPDATE name = {newName:String} WHERE score BETWEEN {low:Float64} AND {high:Float64}',
     );
   });
+
+  describe('whereIf', () => {
+    it('adds condition when truthy', () => {
+      const { sql } = qb
+        .update('users')
+        .set('name', qb.param('newName', 'String'))
+        .where('user_id', '=', qb.param('id', 'String'))
+        .whereIf(true, 'score', '>', qb.param('min', 'Float64'))
+        .compile();
+      expect(sql).toContain('WHERE user_id = {id:String} AND score > {min:Float64}');
+    });
+
+    it('skips condition when falsy', () => {
+      const { sql } = qb
+        .update('users')
+        .set('name', qb.param('newName', 'String'))
+        .where('user_id', '=', qb.param('id', 'String'))
+        .whereIf(false, 'score', '>', qb.param('min', 'Float64'))
+        .compile();
+      expect(sql).not.toContain('score');
+    });
+
+    it('skips condition when undefined', () => {
+      const { sql } = qb
+        .update('users')
+        .set('name', qb.param('newName', 'String'))
+        .where('user_id', '=', qb.param('id', 'String'))
+        .whereIf(undefined, 'score', '>', qb.param('min', 'Float64'))
+        .compile();
+      expect(sql).not.toContain('score');
+    });
+  });
 });

--- a/src/query/compile-utils.ts
+++ b/src/query/compile-utils.ts
@@ -2,7 +2,7 @@
  * Shared compilation utilities for SELECT, DELETE, and UPDATE builders.
  */
 
-import type { BetweenOp, ComparisonOp, SetOp, UnaryOp } from './types.js';
+import type { BetweenOp, ComparisonOp, SetOp, UnaryOp, WhereOp } from './types.js';
 import { Expression, Subquery } from './expressions.js';
 import { Param } from './param.js';
 
@@ -79,3 +79,25 @@ export function registerExpressionParams(expr: Expression, ctx: CompileContext):
 
 /** Valid SQL identifier pattern (settings keys, CTE names, cluster names, column names). */
 export const VALID_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/** Parse where() arguments into a WhereClause. Shared by SELECT, DELETE, and UPDATE builders. */
+export function buildWhereClause(
+  columnOrCondition: Expression | string,
+  op?: WhereOp,
+  value?: Param | Expression | [Param | Expression, Param | Expression],
+): WhereClause {
+  if (columnOrCondition instanceof Expression && op === undefined) {
+    return { kind: 'expression', expr: columnOrCondition };
+  }
+  const col = columnOrCondition instanceof Expression ? columnOrCondition.sql : (columnOrCondition as string);
+  if (op === 'IS NULL' || op === 'IS NOT NULL') {
+    return { kind: 'unary', column: col, op };
+  }
+  if (op === 'BETWEEN' || op === 'NOT BETWEEN') {
+    if (!Array.isArray(value) || value.length < 2) {
+      throw new Error(`${op} requires a [low, high] tuple`);
+    }
+    return { kind: 'between', column: col, op, low: value[0]!, high: value[1]! };
+  }
+  return { kind: 'comparison', column: col, op: op as ComparisonOp | SetOp, value: value as Param | Expression };
+}

--- a/src/query/delete-builder.ts
+++ b/src/query/delete-builder.ts
@@ -20,6 +20,7 @@ import { Expression } from './expressions.js';
 import { Param } from './param.js';
 import {
   type WhereClause,
+  buildWhereClause,
   createCompileContext,
   renderWhereClause,
   VALID_IDENTIFIER,
@@ -75,6 +76,18 @@ export class DeleteBuilder<
     return this;
   }
 
+  whereIf(
+    condition: unknown,
+    column: ColumnName<DB, T> | Expression | string,
+    op: WhereOp,
+    value?: Param | Expression | [Param | Expression, Param | Expression],
+  ): this {
+    if (condition) {
+      this._wheres.push(buildWhereClause(column, op, value));
+    }
+    return this;
+  }
+
   compile(): CompiledQuery {
     if (this._wheres.length === 0) {
       throw new Error('DELETE requires at least one WHERE condition');
@@ -90,23 +103,3 @@ export class DeleteBuilder<
   }
 }
 
-function buildWhereClause(
-  columnOrCondition: Expression | string,
-  op?: WhereOp,
-  value?: Param | Expression | [Param | Expression, Param | Expression],
-): WhereClause {
-  if (columnOrCondition instanceof Expression && op === undefined) {
-    return { kind: 'expression', expr: columnOrCondition };
-  }
-  const col = columnOrCondition instanceof Expression ? columnOrCondition.sql : (columnOrCondition as string);
-  if (op === 'IS NULL' || op === 'IS NOT NULL') {
-    return { kind: 'unary', column: col, op };
-  }
-  if (op === 'BETWEEN' || op === 'NOT BETWEEN') {
-    if (!Array.isArray(value) || value.length < 2) {
-      throw new Error(`${op} requires a [low, high] tuple`);
-    }
-    return { kind: 'between', column: col, op, low: value[0]!, high: value[1]! };
-  }
-  return { kind: 'comparison', column: col, op: op as ComparisonOp | SetOp, value: value as Param | Expression };
-}

--- a/src/query/expressions.ts
+++ b/src/query/expressions.ts
@@ -37,6 +37,7 @@ export class ConditionGroup extends Expression {
         return c.sql;
       }
       if (c instanceof Expression) {
+        params.push(...c.params);
         return c.sql;
       }
       const [col, op, val] = c;
@@ -48,6 +49,7 @@ export class ConditionGroup extends Expression {
         params.push(val);
         return `${col} ${op} ${val.toString()}`;
       }
+      params.push(...val.params);
       return `${col} ${op} ${val.sql}`;
     });
     super(`(${parts.join(` ${operator} `)})`);

--- a/src/query/query-builder.ts
+++ b/src/query/query-builder.ts
@@ -98,6 +98,9 @@ export function createQueryBuilder<DB extends DatabaseSchema>(): QueryBuilder<DB
       return createWithBuilder(name, builder, []);
     },
     insertFrom(table: string, selectQuery: { compile(): CompiledQuery<unknown> }) {
+      if (!VALID_IDENTIFIER.test(table)) {
+        throw new Error(`Invalid table name: "${table}"`);
+      }
       return {
         compile(): CompiledQuery {
           const compiled = selectQuery.compile();
@@ -106,6 +109,9 @@ export function createQueryBuilder<DB extends DatabaseSchema>(): QueryBuilder<DB
       };
     },
     truncate(table: string) {
+      if (!VALID_IDENTIFIER.test(table)) {
+        throw new Error(`Invalid table name: "${table}"`);
+      }
       return {
         compile(): CompiledQuery {
           return { sql: `TRUNCATE TABLE ${table}`, params: {} };
@@ -113,6 +119,12 @@ export function createQueryBuilder<DB extends DatabaseSchema>(): QueryBuilder<DB
       };
     },
     exchangeTables(tableA: string, tableB: string) {
+      if (!VALID_IDENTIFIER.test(tableA)) {
+        throw new Error(`Invalid table name: "${tableA}"`);
+      }
+      if (!VALID_IDENTIFIER.test(tableB)) {
+        throw new Error(`Invalid table name: "${tableB}"`);
+      }
       return {
         compile(): CompiledQuery {
           return { sql: `EXCHANGE TABLES ${tableA} AND ${tableB}`, params: {} };

--- a/src/query/select-builder.ts
+++ b/src/query/select-builder.ts
@@ -25,6 +25,7 @@ import { Expression, Subquery } from './expressions.js';
 import { Param } from './param.js';
 import {
   type WhereClause,
+  buildWhereClause,
   createCompileContext,
   mergeParams,
   registerExpressionParams,
@@ -33,7 +34,7 @@ import {
   VALID_IDENTIFIER,
 } from './compile-utils.js';
 
-const TIME_INTERVAL_FN: Record<string, string> = {
+const TIME_INTERVAL_FN: Record<'minute' | 'hour' | 'day' | 'week' | 'month' | 'year', string> = {
   minute: 'toStartOfMinute',
   hour: 'toStartOfHour',
   day: 'toStartOfDay',
@@ -258,18 +259,16 @@ export class SelectBuilder<
   }
 
   having(column: string | Expression, op: ComparisonOp, value: Param | Expression): this;
+  having(column: string | Expression, op: SetOp, value: Param | Expression): this;
+  having(column: string | Expression, op: UnaryOp): this;
+  having(column: string | Expression, op: BetweenOp, value: [Param | Expression, Param | Expression]): this;
   having(condition: Expression): this;
   having(
     columnOrCondition: string | Expression,
-    op?: ComparisonOp,
-    value?: Param | Expression,
+    op?: WhereOp,
+    value?: Param | Expression | [Param | Expression, Param | Expression],
   ): this {
-    if (columnOrCondition instanceof Expression && op === undefined) {
-      this._havings.push({ kind: 'expression', expr: columnOrCondition });
-      return this;
-    }
-    const col = columnOrCondition instanceof Expression ? columnOrCondition.sql : columnOrCondition;
-    this._havings.push({ kind: 'comparison', column: col, op: op!, value: value! });
+    this._havings.push(buildWhereClause(columnOrCondition, op, value));
     return this;
   }
 
@@ -462,24 +461,3 @@ export function except<T = Record<string, unknown>>(...queries: { compile(): Com
   return setOperation('EXCEPT', ...queries);
 }
 
-/** Parse where() arguments into a WhereClause. Shared by where() and prewhere(). */
-function buildWhereClause(
-  columnOrCondition: Expression | string,
-  op?: WhereOp,
-  value?: Param | Expression | [Param | Expression, Param | Expression],
-): WhereClause {
-  if (columnOrCondition instanceof Expression && op === undefined) {
-    return { kind: 'expression', expr: columnOrCondition };
-  }
-  const col = columnOrCondition instanceof Expression ? columnOrCondition.sql : (columnOrCondition as string);
-  if (op === 'IS NULL' || op === 'IS NOT NULL') {
-    return { kind: 'unary', column: col, op };
-  }
-  if (op === 'BETWEEN' || op === 'NOT BETWEEN') {
-    if (!Array.isArray(value) || value.length < 2) {
-      throw new Error(`${op} requires a [low, high] tuple`);
-    }
-    return { kind: 'between', column: col, op, low: value[0]!, high: value[1]! };
-  }
-  return { kind: 'comparison', column: col, op: op as ComparisonOp | SetOp, value: value as Param | Expression };
-}

--- a/src/query/update-builder.ts
+++ b/src/query/update-builder.ts
@@ -20,6 +20,7 @@ import { Expression } from './expressions.js';
 import { Param } from './param.js';
 import {
   type WhereClause,
+  buildWhereClause,
   createCompileContext,
   renderValue,
   renderWhereClause,
@@ -91,6 +92,18 @@ export class UpdateBuilder<
     return this;
   }
 
+  whereIf(
+    condition: unknown,
+    column: ColumnName<DB, T> | Expression | string,
+    op: WhereOp,
+    value?: Param | Expression | [Param | Expression, Param | Expression],
+  ): this {
+    if (condition) {
+      this._wheres.push(buildWhereClause(column, op, value));
+    }
+    return this;
+  }
+
   compile(): CompiledQuery {
     if (this._sets.length === 0) {
       throw new Error('UPDATE requires at least one SET assignment');
@@ -115,23 +128,3 @@ export class UpdateBuilder<
   }
 }
 
-function buildWhereClause(
-  columnOrCondition: Expression | string,
-  op?: WhereOp,
-  value?: Param | Expression | [Param | Expression, Param | Expression],
-): WhereClause {
-  if (columnOrCondition instanceof Expression && op === undefined) {
-    return { kind: 'expression', expr: columnOrCondition };
-  }
-  const col = columnOrCondition instanceof Expression ? columnOrCondition.sql : (columnOrCondition as string);
-  if (op === 'IS NULL' || op === 'IS NOT NULL') {
-    return { kind: 'unary', column: col, op };
-  }
-  if (op === 'BETWEEN' || op === 'NOT BETWEEN') {
-    if (!Array.isArray(value) || value.length < 2) {
-      throw new Error(`${op} requires a [low, high] tuple`);
-    }
-    return { kind: 'between', column: col, op, low: value[0]!, high: value[1]! };
-  }
-  return { kind: 'comparison', column: col, op: op as ComparisonOp | SetOp, value: value as Param | Expression };
-}


### PR DESCRIPTION
## Summary

Comprehensive codebase review surfaced 14 issues across query builder, codegen, client, and migrate modules. All fixed.

### Bugs fixed
- **ConditionGroup drops Expression params** — `or()`/`and()` with `fn.raw()` carrying params would emit the placeholder but never register the param, causing ClickHouse to reject the query
- **`stream()` missing `<T>`** — yielded rows lost their type, silently becoming `unknown[]`
- **`quoteSingleString` used `\'`** — wrong for ClickHouse, should be `''`
- **`quoteProperty` didn't escape quotes** — column names with special chars produced invalid TypeScript
- **`snakeToPascal` broken for digit-leading tables** — `2023_events` → `2023Events` (invalid TS identifier), now `_2023Events`
- **`parseSourceTable` didn't strip double-quotes** — `"db"."table"` left quotes in source name

### Deduplication
- **`buildWhereClause` extracted to compile-utils** — was copy-pasted in select-builder, delete-builder, update-builder
- **`having()` refactored** to use shared `buildWhereClause`, now supports all operator types (BETWEEN, IS NULL, IN, etc.)

### Security
- **Identifier validation** added to `truncate()`, `exchangeTables()`, `insertFrom()` — prevents SQL injection via table names

### Consistency
- **`whereIf()` added to DeleteBuilder and UpdateBuilder** — was only on SelectBuilder
- **`TIME_INTERVAL_FN` properly typed** — narrowed from `Record<string, string>`

### Cleanup
- Removed dead `GeneratorOptions.command` field
- Fixed CLI version `0.1.0` → `0.9.0`
- Rebuilt dist

## Test plan
- 448 tests (up from 431), all passing
- Typecheck clean