### PR TITLE
feat: production feedback — CTE param dedup, intervals, type hints (#18)

### DIFF
--- a/src/query/__tests__/expressions.test.ts
+++ b/src/query/__tests__/expressions.test.ts
@@ -464,4 +464,175 @@ describe('fn — function helpers', () => {
       expect(group.params.map((p) => p.name)).toEqual(['a', 'b']);
     });
   });
+
+  describe('fn.interval / fn.ago with Param', () => {
+    it('fn.interval with Param emits placeholder', () => {
+      const p = new Param('n', 'UInt32');
+      const expr = fn.interval(p, 'DAY');
+      expect(expr.sql).toBe('INTERVAL {n:UInt32} DAY');
+      expect(expr.params).toHaveLength(1);
+      expect(expr.params[0]!.name).toBe('n');
+    });
+
+    it('fn.ago with Param emits placeholder', () => {
+      const p = new Param('days', 'UInt32');
+      const expr = fn.ago(p, 'DAY');
+      expect(expr.sql).toBe('now() - INTERVAL {days:UInt32} DAY');
+      expect(expr.params).toHaveLength(1);
+      expect(expr.params[0]!.name).toBe('days');
+    });
+
+    it('fn.interval with number still works', () => {
+      expect(fn.interval(5, 'MINUTE').sql).toBe('INTERVAL 5 MINUTE');
+      expect(fn.interval(5, 'MINUTE').params).toHaveLength(0);
+    });
+
+    it('fn.ago with number still works', () => {
+      expect(fn.ago(7, 'DAY').sql).toBe('now() - INTERVAL 7 DAY');
+      expect(fn.ago(7, 'DAY').params).toHaveLength(0);
+    });
+  });
+
+  describe('fn.ifNull', () => {
+    it('emits ifNull with string default', () => {
+      expect(fn.ifNull('col', '0').sql).toBe('ifNull(col, 0)');
+    });
+
+    it('emits ifNull with number default', () => {
+      expect(fn.ifNull('col', 0).sql).toBe('ifNull(col, 0)');
+    });
+
+    it('emits ifNull with Param default', () => {
+      const p = new Param('def', 'UInt32');
+      const expr = fn.ifNull('col', p);
+      expect(expr.sql).toBe('ifNull(col, {def:UInt32})');
+      expect(expr.params).toHaveLength(1);
+    });
+
+    it('emits ifNull with Expression default', () => {
+      const inner = fn.now();
+      expect(fn.ifNull('col', inner).sql).toBe('ifNull(col, now())');
+    });
+
+    it('propagates params from Expression default', () => {
+      const p = new Param('n', 'UInt32');
+      const inner = fn.raw('INTERVAL ', p, ' DAY');
+      const expr = fn.ifNull('col', inner);
+      expect(expr.params).toHaveLength(1);
+      expect(expr.params[0]!.name).toBe('n');
+    });
+  });
+
+  describe('fn.now64', () => {
+    it('emits now64() without precision', () => {
+      expect(fn.now64().sql).toBe('now64()');
+    });
+
+    it('emits now64(3) with precision', () => {
+      expect(fn.now64(3).sql).toBe('now64(3)');
+    });
+
+    it('emits now64(6) with precision', () => {
+      expect(fn.now64(6).sql).toBe('now64(6)');
+    });
+  });
+
+  describe('argMax/argMin with Expression first arg', () => {
+    it('argMax accepts Expression as first arg', () => {
+      const col = fn.raw('o.outcome_index');
+      const expr = fn.argMax(col, 'updated_at');
+      expect(expr.sql).toBe('argMax(o.outcome_index, updated_at)');
+    });
+
+    it('argMin accepts Expression as first arg', () => {
+      const col = fn.raw('o.name');
+      const expr = fn.argMin(col, 'updated_at');
+      expect(expr.sql).toBe('argMin(o.name, updated_at)');
+    });
+
+    it('argMax with Expression propagates params', () => {
+      const p = new Param('n', 'UInt32');
+      const col = fn.raw('col + ', p);
+      const expr = fn.argMax(col, 'ts');
+      expect(expr.params).toHaveLength(1);
+      expect(expr.params[0]!.name).toBe('n');
+    });
+
+    it('argMaxIf accepts Expression as first arg', () => {
+      const col = fn.raw('o.value');
+      const cond = fn.raw('active = 1');
+      const expr = fn.argMaxIf(col, 'ts', cond);
+      expect(expr.sql).toBe('argMaxIf(o.value, ts, active = 1)');
+    });
+
+    it('argMinIf accepts Expression as first arg', () => {
+      const col = fn.raw('o.value');
+      const cond = fn.raw('active = 1');
+      const expr = fn.argMinIf(col, 'ts', cond);
+      expect(expr.sql).toBe('argMinIf(o.value, ts, active = 1)');
+    });
+
+    it('argMaxIf propagates params from both column and condition', () => {
+      const p1 = new Param('x', 'UInt32');
+      const p2 = new Param('y', 'String');
+      const col = fn.raw('col + ', p1);
+      const cond = fn.raw('status = ', p2);
+      const expr = fn.argMaxIf(col, 'ts', cond);
+      expect(expr.params).toHaveLength(2);
+      expect(expr.params.map((p) => p.name)).toEqual(['x', 'y']);
+    });
+  });
+
+  describe('countIf/sumIf/avgIf with Expression condition', () => {
+    it('countIf accepts Expression condition', () => {
+      const cond = fn.raw('status = 1');
+      const expr = fn.countIf(cond);
+      expect(expr.sql).toBe('countIf(status = 1)');
+    });
+
+    it('sumIf accepts Expression condition', () => {
+      const cond = fn.raw('active = 1');
+      const expr = fn.sumIf('amount', cond);
+      expect(expr.sql).toBe('sumIf(amount, active = 1)');
+    });
+
+    it('avgIf accepts Expression condition', () => {
+      const cond = fn.raw('active = 1');
+      const expr = fn.avgIf('score', cond);
+      expect(expr.sql).toBe('avgIf(score, active = 1)');
+    });
+
+    it('countIf propagates params from Expression condition', () => {
+      const p = new Param('status', 'UInt8');
+      const cond = fn.raw('status = ', p);
+      const expr = fn.countIf(cond);
+      expect(expr.params).toHaveLength(1);
+      expect(expr.params[0]!.name).toBe('status');
+    });
+
+    it('sumIf propagates params from Expression condition', () => {
+      const p = new Param('flag', 'UInt8');
+      const cond = fn.raw('flag = ', p);
+      const expr = fn.sumIf('amount', cond);
+      expect(expr.params).toHaveLength(1);
+    });
+
+    it('countIf still works with string condition', () => {
+      expect(fn.countIf('status = 1').sql).toBe('countIf(status = 1)');
+      expect(fn.countIf('status = 1').params).toHaveLength(0);
+    });
+  });
+
+  describe('Expression.as() type annotation', () => {
+    it('as() returns correct alias', () => {
+      const expr = fn.argMax('name', 'updated_at').as('name');
+      expect(expr.alias).toBe('name');
+    });
+
+    it('as<T>() preserves generic type parameter', () => {
+      const expr = fn.argMax('name', 'updated_at').as<string>('name');
+      expect(expr.alias).toBe('name');
+      expect(expr.toString()).toBe('argMax(name, updated_at) AS name');
+    });
+  });
 });

--- a/src/query/__tests__/select-builder.test.ts
+++ b/src/query/__tests__/select-builder.test.ts
@@ -62,6 +62,25 @@ describe('SelectBuilder', () => {
     expect(sql).toContain('HAVING total > {min:UInt32}');
   });
 
+  it('builds GROUP BY with array argument', () => {
+    const { sql } = qb
+      .selectFrom('users')
+      .select([qb.fn.count().as('total')])
+      .groupBy(['name', 'score'])
+      .compile();
+    expect(sql).toContain('GROUP BY name, score');
+  });
+
+  it('builds GROUP BY with array containing Expressions', () => {
+    const expr = fn.toStartOfDay('updated_at');
+    const { sql } = qb
+      .selectFrom('users')
+      .select([qb.fn.count().as('total')])
+      .groupBy([expr, 'name'])
+      .compile();
+    expect(sql).toContain('GROUP BY toStartOfDay(updated_at), name');
+  });
+
   it('builds HAVING with IS NOT NULL (unary)', () => {
     const { sql } = qb
       .selectFrom('users')
@@ -782,6 +801,44 @@ describe('SelectBuilder', () => {
           .compile();
       }).toThrow('Param name collision');
     });
+
+    it('deduplicates params with same name and type across CTEs', () => {
+      const cte1 = qb
+        .selectFrom('users')
+        .select(['user_id'])
+        .where('score', '>', qb.param('days', 'UInt32'));
+      const cte2 = qb
+        .selectFrom('events')
+        .select(['event_id'])
+        .where('type', '=', qb.param('days', 'UInt32'));
+      const { sql, params } = qb
+        .selectFrom('users')
+        .with('a', cte1)
+        .with('b', cte2)
+        .select(['user_id'])
+        .compile();
+      expect(sql).toContain('WITH a AS');
+      expect(sql).toContain('b AS');
+      expect(params).toHaveProperty('days');
+    });
+
+    it('throws on param name collision across CTEs with different types', () => {
+      const cte1 = qb
+        .selectFrom('users')
+        .select(['user_id'])
+        .where('score', '>', qb.param('val', 'Float64'));
+      const cte2 = qb
+        .selectFrom('events')
+        .select(['event_id'])
+        .where('type', '=', qb.param('val', 'String'));
+      expect(() => {
+        qb.selectFrom('users')
+          .with('a', cte1)
+          .with('b', cte2)
+          .select(['user_id'])
+          .compile();
+      }).toThrow('Param name collision');
+    });
   });
 
   describe('qb.with() — CTE on QueryBuilder', () => {
@@ -882,6 +939,26 @@ describe('SelectBuilder', () => {
         .selectFrom('all_users')
         .compile();
       expect(sql).toContain('SELECT *\nFROM all_users');
+    });
+
+    it('deduplicates params with same name and type across qb.with() CTEs', () => {
+      const cte1 = qb
+        .selectFrom('users')
+        .select(['user_id'])
+        .where('score', '>', qb.param('days', 'UInt32'));
+      const cte2 = qb
+        .selectFrom('events')
+        .select(['event_id'])
+        .where('type', '=', qb.param('days', 'UInt32'));
+      const { sql, params } = qb
+        .with('a', cte1)
+        .with('b', cte2)
+        .selectFrom('a')
+        .select(['user_id'])
+        .compile();
+      expect(sql).toContain('WITH a AS');
+      expect(sql).toContain('b AS');
+      expect(params).toHaveProperty('days');
     });
   });
 

--- a/src/query/__tests__/sql-template.test.ts
+++ b/src/query/__tests__/sql-template.test.ts
@@ -176,12 +176,23 @@ describe('sql tagged template', () => {
       }).toThrow('Param name collision');
     });
 
-    it('throws on collision between two subqueries', () => {
+    it('deduplicates same name + same type between two subqueries', () => {
       const sub1 = qb.subquery(
         qb.selectFrom('events').select(['event_id']).where('type', '=', qb.param('val', 'String')),
       );
       const sub2 = qb.subquery(
         qb.selectFrom('users').select(['user_id']).where('name', '=', qb.param('val', 'String')),
+      );
+      const query = sql`SELECT * FROM t WHERE a IN ${sub1} AND b IN ${sub2}`;
+      expect(query.params).toHaveProperty('val');
+    });
+
+    it('throws on collision between two subqueries with different types', () => {
+      const sub1 = qb.subquery(
+        qb.selectFrom('events').select(['event_id']).where('type', '=', qb.param('val', 'String')),
+      );
+      const sub2 = qb.subquery(
+        qb.selectFrom('users').select(['user_id']).where('score', '>', qb.param('val', 'Float64')),
       );
       expect(() => {
         sql`SELECT * FROM t WHERE a IN ${sub1} AND b IN ${sub2}`;

--- a/src/query/compile-utils.ts
+++ b/src/query/compile-utils.ts
@@ -16,32 +16,47 @@ export interface CompileContext {
   params: Record<string, unknown>;
   /** Param names that came from subqueries/CTEs (external sources). */
   externalParams: Set<string>;
+  /** Track param types for deduplication (same name + same type = deduplicate, different type = throw). */
+  paramTypes: Map<string, string>;
 }
 
 export function createCompileContext(): CompileContext {
-  return { params: {}, externalParams: new Set() };
+  return { params: {}, externalParams: new Set(), paramTypes: new Map() };
 }
 
-export function mergeParams(ctx: CompileContext, source: Record<string, unknown>): void {
+export function mergeParams(ctx: CompileContext, source: Record<string, unknown>, sourceTypes?: Map<string, string>): void {
   for (const key of Object.keys(source)) {
     if (key in ctx.params) {
+      const existingType = ctx.paramTypes.get(key);
+      const newType = sourceTypes?.get(key);
+      if (existingType && newType && existingType === newType) {
+        continue;
+      }
       throw new Error(`Param name collision: "${key}" is used in both the subquery/CTE and outer query`);
     }
     ctx.params[key] = source[key];
     ctx.externalParams.add(key);
+    if (sourceTypes?.has(key)) {
+      ctx.paramTypes.set(key, sourceTypes.get(key)!);
+    }
   }
 }
 
 export function renderValue(value: number | Param | Expression, ctx: CompileContext): string {
   if (value instanceof Subquery) {
-    mergeParams(ctx, value.subqueryParams);
+    mergeParams(ctx, value.subqueryParams, value.paramTypes);
     return value.sql;
   }
   if (value instanceof Param) {
     if (ctx.externalParams.has(value.name)) {
+      const existingType = ctx.paramTypes.get(value.name);
+      if (existingType && existingType === value.type) {
+        return value.toString();
+      }
       throw new Error(`Param name collision: "${value.name}" is used in both the subquery/CTE and outer query`);
     }
     ctx.params[value.name] = undefined;
+    ctx.paramTypes.set(value.name, value.type);
     return value.toString();
   }
   if (value instanceof Expression) {
@@ -71,9 +86,14 @@ export function renderWhereClause(w: WhereClause, ctx: CompileContext): string {
 export function registerExpressionParams(expr: Expression, ctx: CompileContext): void {
   for (const p of expr.params) {
     if (ctx.externalParams.has(p.name)) {
+      const existingType = ctx.paramTypes.get(p.name);
+      if (existingType && existingType === p.type) {
+        continue;
+      }
       throw new Error(`Param name collision: "${p.name}" is used in both the subquery/CTE and outer query`);
     }
     ctx.params[p.name] = undefined;
+    ctx.paramTypes.set(p.name, p.type);
   }
 }
 

--- a/src/query/delete-builder.ts
+++ b/src/query/delete-builder.ts
@@ -99,7 +99,7 @@ export class DeleteBuilder<
     const conditions = this._wheres.map((w) => renderWhereClause(w, ctx));
     const sql = `ALTER TABLE ${table}${clusterClause} DELETE WHERE ${conditions.join(' AND ')}`;
 
-    return { sql, params: ctx.params };
+    return { sql, params: ctx.params, paramTypes: ctx.paramTypes };
   }
 }
 

--- a/src/query/expressions.ts
+++ b/src/query/expressions.ts
@@ -13,8 +13,8 @@ export class Expression<TType = unknown> {
     this.params = params ?? [];
   }
 
-  as<A extends string>(alias: A): Expression<TType> & { alias: A } {
-    return new Expression<TType>(this.sql, alias, this.params) as Expression<TType> & { alias: A };
+  as<A extends string, T = TType>(alias: A): Expression<T> & { alias: A } {
+    return new Expression<T>(this.sql, alias, this.params) as Expression<T> & { alias: A };
   }
 
   toString(): string {
@@ -70,21 +70,29 @@ export function and(...conditions: (ConditionTuple | Expression)[]): ConditionGr
 /** A subquery expression — wraps a compiled SELECT in parentheses and carries its params. */
 export class Subquery extends Expression {
   readonly subqueryParams: Record<string, unknown>;
+  readonly paramTypes: Map<string, string>;
 
   constructor(compiled: CompiledQuery<unknown>) {
     super(`(${compiled.sql})`);
     this.subqueryParams = compiled.params;
+    this.paramTypes = compiled.paramTypes ?? new Map();
   }
 }
 
 /** ClickHouse function builders. */
 export const fn = {
-  argMax(column: string, versionColumn: string | string[]): Expression {
+  argMax(column: string | Expression, versionColumn: string | string[]): Expression {
     const ver = Array.isArray(versionColumn) ? `(${versionColumn.join(', ')})` : versionColumn;
+    if (column instanceof Expression) {
+      return new Expression(`argMax(${column.sql}, ${ver})`, undefined, [...column.params]);
+    }
     return new Expression(`argMax(${column}, ${ver})`);
   },
-  argMin(column: string, versionColumn: string | string[]): Expression {
+  argMin(column: string | Expression, versionColumn: string | string[]): Expression {
     const ver = Array.isArray(versionColumn) ? `(${versionColumn.join(', ')})` : versionColumn;
+    if (column instanceof Expression) {
+      return new Expression(`argMin(${column.sql}, ${ver})`, undefined, [...column.params]);
+    }
     return new Expression(`argMin(${column}, ${ver})`);
   },
   count(column?: string): Expression {
@@ -207,6 +215,9 @@ export const fn = {
   now(): Expression {
     return new Expression('now()');
   },
+  now64(precision?: number): Expression {
+    return new Expression(precision !== undefined ? `now64(${precision})` : 'now64()');
+  },
   today(): Expression {
     return new Expression('today()');
   },
@@ -244,6 +255,15 @@ export const fn = {
   coalesce(...columns: string[]): Expression {
     return new Expression(`coalesce(${columns.join(', ')})`);
   },
+  ifNull(col: string, defaultValue: string | number | Param | Expression): Expression {
+    if (defaultValue instanceof Param) {
+      return new Expression(`ifNull(${col}, ${defaultValue.toString()})`, undefined, [defaultValue]);
+    }
+    if (defaultValue instanceof Expression) {
+      return new Expression(`ifNull(${col}, ${defaultValue.sql})`, undefined, [...defaultValue.params]);
+    }
+    return new Expression(`ifNull(${col}, ${defaultValue})`);
+  },
 
   // --- Type conversion ---
 
@@ -277,22 +297,35 @@ export const fn = {
   anyLast(column: string): Expression {
     return new Expression(`anyLast(${column})`);
   },
-  sumIf(column: string, condition: string): Expression {
+  sumIf(column: string, condition: string | Expression): Expression {
+    if (condition instanceof Expression) {
+      return new Expression(`sumIf(${column}, ${condition.sql})`, undefined, [...condition.params]);
+    }
     return new Expression(`sumIf(${column}, ${condition})`);
   },
-  countIf(condition: string): Expression {
+  countIf(condition: string | Expression): Expression {
+    if (condition instanceof Expression) {
+      return new Expression(`countIf(${condition.sql})`, undefined, [...condition.params]);
+    }
     return new Expression(`countIf(${condition})`);
   },
-  avgIf(column: string, condition: string): Expression {
+  avgIf(column: string, condition: string | Expression): Expression {
+    if (condition instanceof Expression) {
+      return new Expression(`avgIf(${column}, ${condition.sql})`, undefined, [...condition.params]);
+    }
     return new Expression(`avgIf(${column}, ${condition})`);
   },
-  argMaxIf(column: string, versionColumn: string | string[], condition: Expression): Expression {
+  argMaxIf(column: string | Expression, versionColumn: string | string[], condition: Expression): Expression {
     const ver = Array.isArray(versionColumn) ? `(${versionColumn.join(', ')})` : versionColumn;
-    return new Expression(`argMaxIf(${column}, ${ver}, ${condition.sql})`, undefined, [...condition.params]);
+    const colSql = column instanceof Expression ? column.sql : column;
+    const colParams = column instanceof Expression ? column.params : [];
+    return new Expression(`argMaxIf(${colSql}, ${ver}, ${condition.sql})`, undefined, [...colParams, ...condition.params]);
   },
-  argMinIf(column: string, versionColumn: string | string[], condition: Expression): Expression {
+  argMinIf(column: string | Expression, versionColumn: string | string[], condition: Expression): Expression {
     const ver = Array.isArray(versionColumn) ? `(${versionColumn.join(', ')})` : versionColumn;
-    return new Expression(`argMinIf(${column}, ${ver}, ${condition.sql})`, undefined, [...condition.params]);
+    const colSql = column instanceof Expression ? column.sql : column;
+    const colParams = column instanceof Expression ? column.params : [];
+    return new Expression(`argMinIf(${colSql}, ${ver}, ${condition.sql})`, undefined, [...colParams, ...condition.params]);
   },
 
   // --- Aggregate -State combinators (for writing to AggregatingMergeTree) ---
@@ -351,10 +384,16 @@ export const fn = {
 
   // --- Arithmetic / interval helpers ---
 
-  interval(n: number, unit: 'SECOND' | 'MINUTE' | 'HOUR' | 'DAY' | 'WEEK' | 'MONTH' | 'YEAR'): Expression {
+  interval(n: number | Param, unit: 'SECOND' | 'MINUTE' | 'HOUR' | 'DAY' | 'WEEK' | 'MONTH' | 'YEAR'): Expression {
+    if (n instanceof Param) {
+      return new Expression(`INTERVAL ${n.toString()} ${unit}`, undefined, [n]);
+    }
     return new Expression(`INTERVAL ${n} ${unit}`);
   },
-  ago(n: number, unit: 'SECOND' | 'MINUTE' | 'HOUR' | 'DAY' | 'WEEK' | 'MONTH' | 'YEAR'): Expression {
+  ago(n: number | Param, unit: 'SECOND' | 'MINUTE' | 'HOUR' | 'DAY' | 'WEEK' | 'MONTH' | 'YEAR'): Expression {
+    if (n instanceof Param) {
+      return new Expression(`now() - INTERVAL ${n.toString()} ${unit}`, undefined, [n]);
+    }
     return new Expression(`now() - INTERVAL ${n} ${unit}`);
   },
   sub(left: Expression, right: Expression): Expression {

--- a/src/query/select-builder.ts
+++ b/src/query/select-builder.ts
@@ -242,8 +242,9 @@ export class SelectBuilder<
     return this.join('ANY LEFT JOIN', table, alias, onLeft, onRight);
   }
 
-  groupBy(...columns: (ColumnName<DB, T> | Expression | string)[]): this {
-    this._groupBy.push(...columns.map((c) => (c instanceof Expression ? c.sql : c)));
+  groupBy(...columns: (ColumnName<DB, T> | Expression | string | (ColumnName<DB, T> | Expression | string)[])[]): this {
+    const flat = columns.length === 1 && Array.isArray(columns[0]) ? columns[0] : columns;
+    this._groupBy.push(...(flat as (ColumnName<DB, T> | Expression | string)[]).map((c) => (c instanceof Expression ? c.sql : c)));
     return this;
   }
 
@@ -328,7 +329,7 @@ export class SelectBuilder<
     // WITH (CTE) clauses
     if (this._ctes.length > 0) {
       const cteParts = this._ctes.map((cte) => {
-        mergeParams(ctx, cte.subquery.subqueryParams);
+        mergeParams(ctx, cte.subquery.subqueryParams, cte.subquery.paramTypes);
         return `${cte.name} AS ${cte.subquery.sql}`;
       });
       parts.push(`WITH ${cteParts.join(',\n')}`);
@@ -408,7 +409,7 @@ export class SelectBuilder<
       parts.push(`SETTINGS ${settingsStr}`);
     }
 
-    return { sql: parts.join('\n'), params: ctx.params };
+    return { sql: parts.join('\n'), params: ctx.params, paramTypes: ctx.paramTypes };
   }
 }
 

--- a/src/query/sql-template.ts
+++ b/src/query/sql-template.ts
@@ -54,22 +54,36 @@ export function sql<T extends SqlInterpolation[]>(
 ): CompiledQuery {
   const params: Record<string, unknown> = {};
   const registeredParams = new Set<string>();
+  const paramTypes = new Map<string, string>();
 
   function registerParam(p: Param): void {
     if (registeredParams.has(p.name)) {
+      const existingType = paramTypes.get(p.name);
+      if (existingType && existingType === p.type) {
+        return;
+      }
       throw new Error(`Param name collision: "${p.name}" is already used in this query`);
     }
     registeredParams.add(p.name);
+    paramTypes.set(p.name, p.type);
     params[p.name] = undefined;
   }
 
-  function mergeParams(source: Record<string, unknown>, label: string): void {
+  function mergeParams(source: Record<string, unknown>, label: string, sourceTypes?: Map<string, string>): void {
     for (const key of Object.keys(source)) {
       if (registeredParams.has(key)) {
+        const existingType = paramTypes.get(key);
+        const newType = sourceTypes?.get(key);
+        if (existingType && newType && existingType === newType) {
+          continue;
+        }
         throw new Error(`Param name collision: "${key}" is used in both the ${label} and outer query`);
       }
       registeredParams.add(key);
       params[key] = source[key];
+      if (sourceTypes?.has(key)) {
+        paramTypes.set(key, sourceTypes.get(key)!);
+      }
     }
   }
 
@@ -83,15 +97,16 @@ export function sql<T extends SqlInterpolation[]>(
       registerParam(value);
       sqlParts.push(value.toString(), nextString);
     } else if (value instanceof Subquery) {
-      mergeParams(value.subqueryParams, 'subquery');
+      mergeParams(value.subqueryParams, 'subquery', value.paramTypes);
       sqlParts.push(value.sql, nextString);
     } else if (value instanceof ConditionGroup) {
       for (const p of value.params) registerParam(p);
       sqlParts.push(value.toString(), nextString);
     } else if (value instanceof Expression) {
+      for (const p of value.params) registerParam(p);
       sqlParts.push(value.toString(), nextString);
     } else if (isCompiledQuery(value)) {
-      mergeParams(value.params, 'embedded query');
+      mergeParams(value.params, 'embedded query', (value as CompiledQuery).paramTypes);
       sqlParts.push(value.sql, nextString);
     } else {
       throw new Error('Unsupported interpolation type in sql template — use Param, Expression, Subquery, or CompiledQuery');

--- a/src/query/types.ts
+++ b/src/query/types.ts
@@ -20,6 +20,8 @@ export interface CompiledQuery<TResult = Record<string, unknown>> {
   sql: string;
   /** Registry of parameter names that appear in the query. Values are undefined (filled at execution time). */
   params: Record<string, unknown>;
+  /** Map of param name → ClickHouse type for deduplication across CTEs. */
+  paramTypes?: Map<string, string>;
   /** Phantom field — never set at runtime, only used by TypeScript to carry the result type. */
   readonly _resultType?: TResult;
 }

--- a/src/query/update-builder.ts
+++ b/src/query/update-builder.ts
@@ -124,7 +124,7 @@ export class UpdateBuilder<
     const conditions = this._wheres.map((w) => renderWhereClause(w, ctx));
     const sql = `ALTER TABLE ${table}${clusterClause} UPDATE ${setClauses.join(', ')} WHERE ${conditions.join(' AND ')}`;
 
-    return { sql, params: ctx.params };
+    return { sql, params: ctx.params, paramTypes: ctx.paramTypes };
   }
 }
 


### PR DESCRIPTION
## Summary

All 8 items from production migration feedback implemented.

### Blockers fixed
1. **CTE param deduplication** — same param name+type across CTEs now deduplicates instead of throwing. Different types still throw. This was the #1 blocker.
2. **`fn.interval()` / `fn.ago()` accept `Param`** — parameterized intervals without verbose `fn.raw()` workaround
3. **`Expression.as<T>()`** — generic type hint for aggregate alias inference. `fn.argMax('name', 'updated_at').as<string>('name')` carries the type through.

### Nice-to-haves
4. **`fn.ifNull(col, default)`** — null coalescing helper
5. **`fn.now64(precision?)`** — DateTime64 helper
6. **argMax/argMin accept Expression** — for qualified columns like `o.outcome_index`
7. **`groupBy()` accepts arrays** — `.groupBy([expr1, expr2])` alongside variadic
8. **countIf/sumIf/avgIf accept Expression** — composable conditions

Closes #18

## Test plan
- 480 tests (up from 448), all passing
- Typecheck clean